### PR TITLE
Add preliminary support for building to WebAssembly

### DIFF
--- a/rpython/translator/driver.py
+++ b/rpython/translator/driver.py
@@ -528,7 +528,18 @@ class TranslationDriver(SimpleTaskEngine):
 
     task_source_js = task_source_c
 
-    task_compile_js = task_compile_c
+    @taskdef(['source_js'], "Compiling js source")
+    def task_compile_js(self):
+        self.task_compile_c()
+        # We also need to copy supporting files such as the
+        # .wasm and .mem file that might have been generated.
+        base_exe = str(self.cbuilder.executable_name)[:-2]
+        for suffix in ("asm.js", "wasm", "wast", "js.mem"):
+            src = base_exe + suffix
+            if os.path.exists(src):
+                dst = os.path.join(self.compute_exe_name().dirname,
+                                   os.path.basename(src))
+                shutil_copy(src, dst)
 
     @taskdef([STACKCHECKINSERTION, '?'+BACKENDOPT, RTYPE], "LLInterpreting")
     def task_llinterpret_lltype(self):

--- a/rpython/translator/platform/emscripten_platform/__init__.py
+++ b/rpython/translator/platform/emscripten_platform/__init__.py
@@ -178,6 +178,9 @@ class EmscriptenPlatform(BasePosix):
         ldflags.extend([
             "-s", repr("EXPORTED_FUNCTIONS=%s" % (exports,)),
         ])
+        # Allow the final build to generate a separate memory file.
+        idx = ldflags.index("--memory-init-file")
+        del ldflags[idx : idx + 2]
         # Do more aggressive (hence more expensive) optimization for final
         # linkage.  Note that this only applies to emscripten itself; llvm
         # still sees "-Os" due to separate use of --llvm-opts.
@@ -191,6 +194,13 @@ class EmscriptenPlatform(BasePosix):
         # optimizations to be performed.
         idx = ldflags.index("--llvm-opts")
         ldflags[idx + 1] = repr(["-Oz"] + self.llvm_opts)
+        # Enable WebAssembly for the final build step.
+        # Doing it only on the final exe makes it quicker and simpler
+        # to run intermedite output steps during the build.
+        ldflags.extend([
+            "-s", "WASM=1",
+            "-s", "\"BINARYEN_METHOD='native-wasm,asmjs'\"",
+        ])
         # Ensure that --llvm-opts appears properly quoted in the makefile.
         idx = ldflags.index("--llvm-opts")
         ldflags[idx + 1] = repr(ldflags[idx + 1])


### PR DESCRIPTION
This adds work-in-progress support for building to WebAssembly with an "almost-asm" fallback.  It's in no way ready for merge, but may be useful if you want to try out preliminary wasm support in this toolchain.